### PR TITLE
Add support for token stemming

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,7 @@ Free software: BSD license
 * Installing_
 * Features_
 * `Text Parsing`_
+* `Stemming`_
 * `Integration with Numpy and Pandas`_
 * `Reporting Bugs`_
 
@@ -87,6 +88,25 @@ Tokens are wrapped within tuples due to the ability to specify any number of n-g
 
 Take a look at the function's docstring for information on how to use ``stopwords``, specify a
 ``min_length`` or ``ignore_numeric`` terms.
+
+Stemming
+--------
+
+When building an inverted index, it can be useful to resolve related strings to a common root.
+
+For example, in a corpus relating to animals it might be useful to derive a singular noun for each animal; as a result, documents containing either the word `dog` or `dogs` could be found under the index entry `dog`.
+
+The `hashedindex` module's text parser provides optional support for stemming by allowing the caller to specify a custom stemmer:
+
+.. code-block:: python
+
+   class NaivePluralStemmer():
+       def stem(self, x):
+           return x.rstrip('s')
+
+   list(textparser.word_tokenize('It was raining cats and dogs', stemmer=NaivePluralStemmer()))
+   [('it',), ('wa',), ('raining',), ('cat',), ('and',), ('dog',)]
+
 
 Integration with Numpy and Pandas
 ---------------------------------

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -17,9 +17,7 @@ class NullStemmer:
 
 
 class InvalidStemmerException(Exception):
-
-    def __init__(self):
-        super().__init__('Stemmer must be an object with a stem(str) function')
+    pass
 
 
 _stopwords = frozenset()
@@ -67,9 +65,9 @@ def get_ngrams(token_list, n=2):
 
 def validate_stemmer(stemmer):
     if not hasattr(stemmer, 'stem'):
-        raise InvalidStemmerException()
+        raise InvalidStemmerException('Stemmer is missing a "stem" function')
     if not callable(stemmer.stem):
-        raise InvalidStemmerException()
+        raise InvalidStemmerException('Stemmer has a "stem" attribute but it is not a function')
 
 
 def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_numeric=True,

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -16,6 +16,12 @@ class NullStemmer:
         return '<NullStemmer>'
 
 
+class InvalidStemmerException(Exception):
+
+    def __init__(self):
+        super().__init__('Stemmer must be an object with a stem(str) function')
+
+
 _stopwords = frozenset()
 _accepted = frozenset(ascii_letters + digits + punctuation) - frozenset('\'')
 
@@ -59,7 +65,17 @@ def get_ngrams(token_list, n=2):
         yield token_list[i:i+n]
 
 
-def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_numeric=True):
+def validate_stemmer(stemmer):
+    if not isinstance(stemmer, object):
+        raise InvalidStemmerException()
+    if not hasattr(stemmer, 'stem'):
+        raise InvalidStemmerException()
+    if not callable(stemmer.stem):
+        raise InvalidStemmerException()
+
+
+def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_numeric=True,
+                  stemmer=None):
     """
     Parses the given text and yields tokens which represent words within
     the given text. Tokens are assumed to be divided by any form of
@@ -67,6 +83,10 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     """
     if ngrams is None:
         ngrams = 1
+    if stemmer is None:
+        stemmer = NullStemmer()
+
+    validate_stemmer(stemmer)
 
     text = re.sub(re.compile('\'s'), '', text)  # Simple heuristic
     text = re.sub(_re_punctuation, '', text)
@@ -75,6 +95,7 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     for tokens in get_ngrams(matched_tokens, ngrams):
         for i in range(len(tokens)):
             tokens[i] = tokens[i].strip(punctuation)
+            tokens[i] = stemmer.stem(tokens[i])
 
             if len(tokens[i]) < min_length or tokens[i] in stopwords:
                 break

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -66,8 +66,6 @@ def get_ngrams(token_list, n=2):
 
 
 def validate_stemmer(stemmer):
-    if not isinstance(stemmer, object):
-        raise InvalidStemmerException()
     if not hasattr(stemmer, 'stem'):
         raise InvalidStemmerException()
     if not callable(stemmer.stem):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -75,7 +75,8 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     """
     Parses the given text and yields tokens which represent words within
     the given text. Tokens are assumed to be divided by any form of
-    whitespace character.
+    whitespace character.  A stemmer may optionally be provided, which will
+    apply a transformation to each token.
     """
     if ngrams is None:
         ngrams = 1


### PR DESCRIPTION
@MichaelAquilina Thanks for developing the `hashedindex` library, it's been extremely useful for constructing some search-like functionality where managing an out-of-process search engine would be overkill.

It'd be great to have support for stemming in the library, and I saw that you were maybe considering this too since there's a `NullStemmer` class defined but unused.  What do you think of this as a proposed initial implementation?