### PR TITLE
Provide option to retain token casing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,8 +86,7 @@ Tokens are wrapped within tuples due to the ability to specify any number of n-g
    [(u'life', u'is'), (u'is', u'about'), (u'about', u'making'), (u'making', u'an'), (u'an', u'impact'),
     (u'impact', u'not'), (u'not', u'making'), (u'making', u'an'), (u'an', u'income')]
 
-Take a look at the function's docstring for information on how to use ``stopwords``, specify a
-``min_length`` or ``ignore_numeric`` terms.
+Take a look at the function's docstring for information on how to use ``stopwords``, specify a ``min_length`` for tokens, and configure token output using the ``ignore_numeric`` and ``retain_casing`` parameters.
 
 Stemming
 --------

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -29,7 +29,7 @@ _punctuation = _punctuation.replace('/', '')
 _punctuation = _punctuation.replace('-', '')
 
 _re_punctuation = re.compile('[%s]' % re.escape(_punctuation))
-_re_token = re.compile(r'[a-z0-9]+')
+_re_token = re.compile(r'[A-z0-9]+')
 
 _url_pattern = (
     r'(https?:\/\/)?(([\da-z-]+)\.){1,2}.([a-z\.]{2,6})(/[\/\w \.-]*)*\/?(\?(\w+=\w+&?)+)?'
@@ -71,7 +71,7 @@ def validate_stemmer(stemmer):
 
 
 def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_numeric=True,
-                  stemmer=None):
+                  stemmer=None, retain_casing=False):
     """
     Parses the given text and yields tokens which represent words within
     the given text. Tokens are assumed to be divided by any form of
@@ -87,8 +87,9 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
 
     text = re.sub(re.compile('\'s'), '', text)  # Simple heuristic
     text = re.sub(_re_punctuation, '', text)
+    text = text if retain_casing else text.lower()
 
-    matched_tokens = re.findall(_re_token, text.lower())
+    matched_tokens = re.findall(_re_token, text)
     for tokens in get_ngrams(matched_tokens, ngrams):
         for i in range(len(tokens)):
             tokens[i] = tokens[i].strip(punctuation)

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -77,6 +77,12 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     the given text. Tokens are assumed to be divided by any form of
     whitespace character.  A stemmer may optionally be provided, which will
     apply a transformation to each token.
+
+    The tokenizer ignores numeric tokens by default; the ignore_numeric
+    parameter can be set to False to include them in the output stream.
+
+    Generated tokens are lowercased by default; the retain_casing flag can
+    be set to True to retain upper/lower casing from the original text.
     """
     if ngrams is None:
         ngrams = 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -128,6 +128,7 @@ class WordTokenizeTestCase(unittest.TestCase):
     def test_retains_casing(self):
         assert list(textparser.word_tokenize(
             text='Three letter acronym (TLA)',
+            retain_casing=True
         )) == [('Three', ), ('letter', ), ('acronym', ), ('TLA',)]
 
     def test_ngrams(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -125,6 +125,11 @@ class WordTokenizeTestCase(unittest.TestCase):
             text='one two 3 four',
         )) == [('one', ), ('two', ), ('four', )]
 
+    def test_retains_casing(self):
+        assert list(textparser.word_tokenize(
+            text='Three letter acronym (TLA)',
+        )) == [('Three', ), ('letter', ), ('acronym', ), ('TLA',)]
+
     def test_ngrams(self):
         assert list(textparser.word_tokenize(
             text='foo bar bomb blar',


### PR DESCRIPTION
I've run into a use case where it's valuable to retain the original casing from the input text in the output token stream.

This change adds support for a `retain_casing` parameter in the `word_tokenize` function; it defaults to `False` (existing behaviour; input text is lowercased), and can be set to `True` if the caller wishes to retain casing.