### PR TITLE
Provide option to retain punctuation tokens

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Tokens are wrapped within tuples due to the ability to specify any number of n-g
    [(u'life', u'is'), (u'is', u'about'), (u'about', u'making'), (u'making', u'an'), (u'an', u'impact'),
     (u'impact', u'not'), (u'not', u'making'), (u'making', u'an'), (u'an', u'income')]
 
-Take a look at the function's docstring for information on how to use ``stopwords``, specify a ``min_length`` for tokens, and configure token output using the ``ignore_numeric`` and ``retain_casing`` parameters.
+Take a look at the function's docstring for information on how to use ``stopwords``, specify a ``min_length`` for tokens, and configure token output using the ``ignore_numeric``, ``retain_casing`` and ``retain_punctuation`` parameters.
 
 Stemming
 --------

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -106,7 +106,6 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     for tokens in get_ngrams(matched_tokens, ngrams):
         for i in range(len(tokens)):
             tokens[i] = stemmer.stem(tokens[i])
-
             if len(tokens[i]) < min_length or tokens[i] in stopwords:
                 break
             if ignore_numeric and isnumeric(tokens[i]):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -26,7 +26,8 @@ _accepted = frozenset(ascii_letters + digits + punctuation) - frozenset('\'')
 # Permit certain punctuation characters within tokens
 _punctuation_exceptions = '\\/-'
 _punctuation = copy(punctuation)
-_punctuation.strip(_punctuation_exceptions)
+for char in _punctuation_exceptions:
+    _punctuation = _punctuation.replace(char, '')
 
 _punctuation_class = '[%s]' % re.escape(_punctuation)
 _token_class = '[A-z0-9%s]' % re.escape(_punctuation_exceptions)

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -23,7 +23,7 @@ class InvalidStemmerException(Exception):
 _stopwords = frozenset()
 _accepted = frozenset(ascii_letters + digits + punctuation) - frozenset('\'')
 
-# Permit certain characters within punctuation
+# Permit certain punctuation characters within tokens
 _punctuation_exceptions = '\\/-'
 _punctuation = copy(punctuation)
 _punctuation.strip(_punctuation_exceptions)

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -30,10 +30,10 @@ for char in _punctuation_exceptions:
     _punctuation = _punctuation.replace(char, '')
 
 _punctuation_class = '[%s]' % re.escape(_punctuation)
-_token_class = '[A-z0-9%s]' % re.escape(_punctuation_exceptions)
+_character_class = '[A-z0-9%s]' % re.escape(_punctuation_exceptions)
 
 _re_punctuation = re.compile(_punctuation_class)
-_re_token = re.compile(r'%s+|%s' % (_token_class, _punctuation_class))
+_re_token = re.compile(r'%s+|%s' % (_character_class, _punctuation_class))
 
 _url_pattern = (
     r'(https?:\/\/)?(([\da-z-]+)\.){1,2}.([a-z\.]{2,6})(/[\/\w \.-]*)*\/?(\?(\w+=\w+&?)+)?'

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -29,7 +29,7 @@ _punctuation = _punctuation.replace('/', '')
 _punctuation = _punctuation.replace('-', '')
 
 _re_punctuation = re.compile('[%s]' % re.escape(_punctuation))
-_re_token = re.compile(r'[A-z0-9]+')
+_re_token = re.compile(r'[A-z0-9]+|\S')
 
 _url_pattern = (
     r'(https?:\/\/)?(([\da-z-]+)\.){1,2}.([a-z\.]{2,6})(/[\/\w \.-]*)*\/?(\?(\w+=\w+&?)+)?'
@@ -71,7 +71,7 @@ def validate_stemmer(stemmer):
 
 
 def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_numeric=True,
-                  stemmer=None, retain_casing=False):
+                  stemmer=None, retain_casing=False, retain_punctuation=False):
     """
     Parses the given text and yields tokens which represent words within
     the given text. Tokens are assumed to be divided by any form of
@@ -92,13 +92,14 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     validate_stemmer(stemmer)
 
     text = re.sub(re.compile('\'s'), '', text)  # Simple heuristic
-    text = re.sub(_re_punctuation, '', text)
+    text = text if retain_punctuation else re.sub(_re_punctuation, '', text)
     text = text if retain_casing else text.lower()
 
     matched_tokens = re.findall(_re_token, text)
     for tokens in get_ngrams(matched_tokens, ngrams):
         for i in range(len(tokens)):
-            tokens[i] = tokens[i].strip(punctuation)
+            if not retain_punctuation:
+                tokens[i] = tokens[i].strip(punctuation)
             tokens[i] = stemmer.stem(tokens[i])
 
             if len(tokens[i]) < min_length or tokens[i] in stopwords:

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -24,7 +24,7 @@ _stopwords = frozenset()
 _accepted = frozenset(ascii_letters + digits + punctuation) - frozenset('\'')
 
 # Permit certain punctuation characters within tokens
-_punctuation_exceptions = '\\/-'
+_punctuation_exceptions = r'\/-'
 _punctuation = copy(punctuation)
 for char in _punctuation_exceptions:
     _punctuation = _punctuation.replace(char, '')

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -105,7 +105,6 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     matched_tokens = re.findall(_re_token, text)
     for tokens in get_ngrams(matched_tokens, ngrams):
         for i in range(len(tokens)):
-            tokens[i] = tokens[i] if retain_punctuation else re.sub(_re_punctuation, '', tokens[i])
             tokens[i] = stemmer.stem(tokens[i])
 
             if len(tokens[i]) < min_length or tokens[i] in stopwords:

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -88,8 +88,8 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     Generated tokens are lowercased by default; the retain_casing flag can
     be set to True to retain upper/lower casing from the original text.
 
-    When retain_punctuation is set to False (default), punctuation characters
-    are removed from the input text.
+    Punctuation characters are removed from the input text by default;
+    the retain_punctuation flag can be set to True to retain them.
     """
     if ngrams is None:
         ngrams = 1

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -88,8 +88,8 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     Generated tokens are lowercased by default; the retain_casing flag can
     be set to True to retain upper/lower casing from the original text.
 
-    Unless retain_punctuation is set to True, punctuation characters will be
-    dropped from the output stream.
+    When retain_punctuation is set to False (default), punctuation characters
+    are removed from the input text.
     """
     if ngrams is None:
         ngrams = 1

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -83,6 +83,9 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
 
     Generated tokens are lowercased by default; the retain_casing flag can
     be set to True to retain upper/lower casing from the original text.
+
+    Unless retain_punctuation is set to True, punctuation characters will be
+    dropped from the output stream.
     """
     if ngrams is None:
         ngrams = 1

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -27,9 +27,10 @@ _punctuation = copy(punctuation)
 _punctuation = _punctuation.replace('\\', '')
 _punctuation = _punctuation.replace('/', '')
 _punctuation = _punctuation.replace('-', '')
+_punctuation_class = '[%s]' % re.escape(_punctuation)
 
-_re_punctuation = re.compile('[%s]' % re.escape(_punctuation))
-_re_token = re.compile(r'[A-z0-9]+|\S')
+_re_punctuation = re.compile(_punctuation_class)
+_re_token = re.compile(r'[A-z0-9]+|%s' % _punctuation_class)
 
 _url_pattern = (
     r'(https?:\/\/)?(([\da-z-]+)\.){1,2}.([a-z\.]{2,6})(/[\/\w \.-]*)*\/?(\?(\w+=\w+&?)+)?'

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -30,10 +30,10 @@ for char in _punctuation_exceptions:
     _punctuation = _punctuation.replace(char, '')
 
 _punctuation_class = '[%s]' % re.escape(_punctuation)
-_character_class = '[A-z0-9%s]' % re.escape(_punctuation_exceptions)
+_word_class = '[A-z0-9%s]+' % re.escape(_punctuation_exceptions)
 
 _re_punctuation = re.compile(_punctuation_class)
-_re_token = re.compile(r'%s+|%s' % (_character_class, _punctuation_class))
+_re_token = re.compile('%s|%s' % (_punctuation_class, _word_class))
 
 _url_pattern = (
     r'(https?:\/\/)?(([\da-z-]+)\.){1,2}.([a-z\.]{2,6})(/[\/\w \.-]*)*\/?(\?(\w+=\w+&?)+)?'

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -28,8 +28,8 @@ _punctuation_exceptions = '\\/-'
 _punctuation = copy(punctuation)
 _punctuation.strip(_punctuation_exceptions)
 
-_token_class = '[A-z0-9%s]' % re.escape(_punctuation_exceptions)
 _punctuation_class = '[%s]' % re.escape(_punctuation)
+_token_class = '[A-z0-9%s]' % re.escape(_punctuation_exceptions)
 
 _re_punctuation = re.compile(_punctuation_class)
 _re_token = re.compile(r'%s+|%s' % (_token_class, _punctuation_class))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -98,6 +98,15 @@ class GetNGramsTestCase(unittest.TestCase):
             ['two', 'three', 'four'],
         ]
 
+    def test_trigram_punctuation_token_list(self):
+        assert list(textparser.get_ngrams(
+            token_list=['!', '@', '#', '$'],
+            n=3,
+        )) == [
+            ['!', '@', '#'],
+            ['@', '#', '$'],
+        ]
+
 
 class WordTokenizeTestCase(unittest.TestCase):
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -130,6 +130,12 @@ class WordTokenizeTestCase(unittest.TestCase):
             text='first. second',
         )) == [('first', ), ('second', )]
 
+    def test_retain_inner_punctuation(self):
+        assert list(textparser.word_tokenize(
+            text='decision is a and/or b',
+            retain_punctuation=True
+        )) == [('decision',), ('is',), ('a',), ('and/or',), ('b',)]
+
     def test_ignores_stopwords(self):
         assert list(textparser.word_tokenize(
             text='The first rule of python is',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -148,6 +148,7 @@ class WordTokenizeTestCase(unittest.TestCase):
     def test_retains_punctuation(self):
         assert list(textparser.word_tokenize(
             text='who, where? (question)',
+            retain_punctuation=True
         )) == [('who', ), (',', ), ('where',), ('?', ), ('(',), ('question',), (')',)]
 
     def test_ngrams(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -156,9 +156,9 @@ class WordTokenizeTestCase(unittest.TestCase):
 
     def test_retains_punctuation(self):
         assert list(textparser.word_tokenize(
-            text='who, where? (question)',
+            text='who, where? (question!)',
             retain_punctuation=True
-        )) == [('who', ), (',', ), ('where',), ('?', ), ('(',), ('question',), (')',)]
+        )) == [('who', ), (',', ), ('where',), ('?', ), ('(',), ('question',), ('!',), (')',)]
 
     def test_ngrams(self):
         assert list(textparser.word_tokenize(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -84,15 +84,6 @@ class GetNGramsTestCase(unittest.TestCase):
             ['two', 'three', 'four'],
         ]
 
-    def test_trigram_punctuation_token_list(self):
-        assert list(textparser.get_ngrams(
-            token_list=['!', '@', '#', '$'],
-            n=3,
-        )) == [
-            ['!', '@', '#'],
-            ['@', '#', '$'],
-        ]
-
 
 class WordTokenizeTestCase(unittest.TestCase):
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 
 from hashedindex import textparser
@@ -68,6 +69,19 @@ class IsNumericTestCase(unittest.TestCase):
         assert not textparser.isnumeric('10 foo')
 
 
+class TokenRegexTestCase(unittest.TestCase):
+
+    def test_plain_text(self):
+        text = 'one two three four'
+        tokens = re.findall(textparser._re_token, text)
+        assert tokens == ['one', 'two', 'three', 'four']
+
+    def test_punctuated_text(self):
+        text = 'one, two (three) four'
+        tokens = re.findall(textparser._re_token, text)
+        assert tokens == ['one', ',', 'two', '(', 'three', ')', 'four']
+
+
 class GetNGramsTestCase(unittest.TestCase):
 
     def test_bigram_token_list(self):
@@ -130,6 +144,11 @@ class WordTokenizeTestCase(unittest.TestCase):
             text='Three letter acronym (TLA)',
             retain_casing=True
         )) == [('Three', ), ('letter', ), ('acronym', ), ('TLA',)]
+
+    def test_retains_punctuation(self):
+        assert list(textparser.word_tokenize(
+            text='who, where? (question)',
+        )) == [('who', ), (',', ), ('where',), ('?', ), ('(',), ('question',), (')',)]
 
     def test_ngrams(self):
         assert list(textparser.word_tokenize(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -107,7 +107,7 @@ class WordTokenizeTestCase(unittest.TestCase):
             text='first. second',
         )) == [('first', ), ('second', )]
 
-    def test_retain_inner_punctuation(self):
+    def test_inner_punctuation(self):
         assert list(textparser.word_tokenize(
             text='decision is a and/or b',
         )) == [('decision',), ('is',), ('a',), ('and/or',), ('b',)]
@@ -142,7 +142,7 @@ class WordTokenizeTestCase(unittest.TestCase):
             retain_punctuation=True
         )) == [('who', ), (',', ), ('where',), ('?', ), ('(',), ('question',), ('!',), (')',)]
 
-    def test_inner_punctuation(self):
+    def test_retains_punctuation_within_tokens(self):
         assert list(textparser.word_tokenize(
             text='is the oven pre-heated?',
             retain_punctuation=True

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,4 +1,3 @@
-import re
 import unittest
 
 from hashedindex import textparser
@@ -67,19 +66,6 @@ class IsNumericTestCase(unittest.TestCase):
     def test_no_numeric(self):
         assert not textparser.isnumeric('foo')
         assert not textparser.isnumeric('10 foo')
-
-
-class TokenRegexTestCase(unittest.TestCase):
-
-    def test_plain_text(self):
-        text = 'one two three four'
-        tokens = re.findall(textparser._re_token, text)
-        assert tokens == ['one', 'two', 'three', 'four']
-
-    def test_punctuated_text(self):
-        text = 'one, two (three) four'
-        tokens = re.findall(textparser._re_token, text)
-        assert tokens == ['one', ',', 'two', '(', 'three', ')', 'four']
 
 
 class GetNGramsTestCase(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -133,7 +133,6 @@ class WordTokenizeTestCase(unittest.TestCase):
     def test_retain_inner_punctuation(self):
         assert list(textparser.word_tokenize(
             text='decision is a and/or b',
-            retain_punctuation=True
         )) == [('decision',), ('is',), ('a',), ('and/or',), ('b',)]
 
     def test_ignores_stopwords(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -160,6 +160,12 @@ class WordTokenizeTestCase(unittest.TestCase):
             retain_punctuation=True
         )) == [('who', ), (',', ), ('where',), ('?', ), ('(',), ('question',), ('!',), (')',)]
 
+    def test_inner_punctuation(self):
+        assert list(textparser.word_tokenize(
+            text='is the oven pre-heated?',
+            retain_punctuation=True
+        )) == [('is', ), ('the', ), ('oven',), ('pre-heated', ), ('?',)]
+
     def test_ngrams(self):
         assert list(textparser.word_tokenize(
             text='foo bar bomb blar',


### PR DESCRIPTION
In the same use case as #15, I'd like to receive punctuation characters in the token output stream.  Although these tokens will not be stored as terms in an index, it can be useful during [highlighting](https://github.com/openculinary/hashedixsearch/blob/4acec272d06d8d0923c2ca3e73522f7c5cf306d7/hashedixsearch/search.py#L141-L186) to reconstruct the original input text verbatim while also using consistent non-punctuation term stemming.

~~To be cautious I've added test coverage not just over the new functionality, but also over some existing ngram-related functionality to make sure it behaves consistently.~~

(apologies for not realizing that I should mention this at the same time during the previous pull request :))

Edit: the ngram-related tests have now been removed, given more confidence that they're not required.