### PR TITLE
Whitespace tokenization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ Take a look at the function's docstring for information on how to use ``stopword
 
 By default, ``word_tokenize`` omits whitespace from the output token stream; whitespaces are rarely useful to include in a document term index.
 
-If you need to perform processing on every token discovered in the text and then re-assemble an output with spacing that matches the input, you may enable the ``tokenize_whitespace`` setting.
+If you need to tokenize text and re-assemble an output with spacing that matches the input, you may enable the ``tokenize_whitespace`` setting.
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Tokens are wrapped within tuples due to the ability to specify any number of n-g
    [(u'life', u'is'), (u'is', u'about'), (u'about', u'making'), (u'making', u'an'), (u'an', u'impact'),
     (u'impact', u'not'), (u'not', u'making'), (u'making', u'an'), (u'an', u'income')]
 
-Take a look at the function's docstring for information on how to use ``stopwords``, specify a ``min_length`` for tokens, and configure token output using the ``ignore_numeric`` and ``retain_casing`` parameters.
+Take a look at the function's docstring for information on how to use ``stopwords``, specify a ``min_length`` for tokens, and configure token output using the ``ignore_numeric``, ``retain_casing`` and ``tokenize_whitespace`` parameters.
 
 Stemming
 --------

--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Tokens are wrapped within tuples due to the ability to specify any number of n-g
 
 Take a look at the function's docstring for information on how to use ``stopwords``, specify a ``min_length`` for tokens, and configure token output using the ``ignore_numeric`` and ``retain_casing`` parameters.
 
-By default, ``word_tokenize`` omits whitespace from the output token stream; whitespaces are rarely useful to include in a search index.
+By default, ``word_tokenize`` omits whitespace from the output token stream; whitespaces are rarely useful to include in a document term index.
 
 If you need to perform processing on every token discovered in the text and then re-assemble an output with spacing that matches the input, you may enable the ``tokenize_whitespace`` setting.
 

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,16 @@ Tokens are wrapped within tuples due to the ability to specify any number of n-g
    [(u'life', u'is'), (u'is', u'about'), (u'about', u'making'), (u'making', u'an'), (u'an', u'impact'),
     (u'impact', u'not'), (u'not', u'making'), (u'making', u'an'), (u'an', u'income')]
 
-Take a look at the function's docstring for information on how to use ``stopwords``, specify a ``min_length`` for tokens, and configure token output using the ``ignore_numeric``, ``retain_casing`` and ``tokenize_whitespace`` parameters.
+Take a look at the function's docstring for information on how to use ``stopwords``, specify a ``min_length`` for tokens, and configure token output using the ``ignore_numeric`` and ``retain_casing`` parameters.
+
+By default, ``word_tokenize`` omits whitespace from the output token stream; whitespaces are rarely useful to include in a search index.
+
+If you need to perform processing on every token discovered in the text and then re-assemble an output with spacing that matches the input, you may enable the ``tokenize_whitespace`` setting.
+
+.. code-block:: python
+
+    list(textparser.word_tokenize('Conventions.  May. Differ.', tokenize_whitespace=True))
+    [('conventions',), ('  ',), ('may',), (' ',), ('differ',)]
 
 Stemming
 --------

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -102,7 +102,6 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     matched_tokens = match_tokens(text)
     for tokens in get_ngrams(matched_tokens, ngrams):
         for i in range(len(tokens)):
-            tokens[i] = tokens[i].strip(punctuation)
             tokens[i] = stemmer.stem(tokens[i])
 
             if len(tokens[i]) < min_length or tokens[i] in stopwords:

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -115,16 +115,16 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
 
     matched_tokens = match_tokens(text, tokenize_whitespace)
     for ngram in get_ngrams(matched_tokens, ngrams):
-        output_token = tuple()
+        output_tokens = tuple()
         for token in ngram:
             token = stemmer.stem(token)
             if len(token) < min_length or token in stopwords:
                 break
             if ignore_numeric and isnumeric(token):
                 break
-            output_token += (token,)
+            output_tokens += (token,)
         else:
-            yield output_token
+            yield output_tokens
 
 
 def isnumeric(text):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -65,7 +65,7 @@ def normalize_unicode(text):
 
 def match_tokens(text, tokenize_whitespace):
     for token in re.findall(_re_token, text):
-        if token.strip() or tokenize_whitespace:
+        if tokenize_whitespace or not token.isspace():
             yield token
 
 

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -116,17 +116,17 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     text = text if retain_casing else text.lower()
 
     matched_tokens = match_tokens(text, tokenize_whitespace)
-    for tokens in get_ngrams(matched_tokens, ngrams):
-        candidate = tuple()
-        for token in tokens:
+    for ngram in get_ngrams(matched_tokens, ngrams):
+        output_token = tuple()
+        for token in ngram:
             token = stemmer.stem(token)
             if len(token) < min_length or token in stopwords:
                 break
             if ignore_numeric and isnumeric(token):
                 break
-            candidate += (token,)
+            output_token += (token,)
         else:
-            yield candidate
+            yield output_token
 
 
 def isnumeric(text):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -26,7 +26,8 @@ _accepted = frozenset(ascii_letters + digits + punctuation) - frozenset('\'')
 # Permit certain characters within punctuation
 _punctuation_exceptions = '\\/-'
 _punctuation = copy(punctuation)
-_punctuation.strip(_punctuation_exceptions)
+for char in _punctuation_exceptions:
+    _punctuation = _punctuation.replace(char, '')
 
 _token_class = '[A-z0-9%s]' % re.escape(_punctuation_exceptions)
 

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -59,12 +59,20 @@ def normalize_unicode(text):
 
 
 def match_tokens(text):
-    return re.findall(_re_token, text)
+    for token in re.findall(_re_token, text):
+        yield token
 
 
 def get_ngrams(tokens, n=2):
-    for i in range(len(tokens) - n + 1):
-        yield tokens[i:i+n]
+    ngram = []
+    for _ in range(0, n):
+        token = next(tokens)
+        ngram.append(token)
+    yield ngram
+    for token in tokens:
+        ngram = ngram[1:]
+        ngram.append(token)
+        yield ngram
 
 
 def validate_stemmer(stemmer):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -29,10 +29,12 @@ _punctuation = copy(punctuation)
 for char in _punctuation_exceptions:
     _punctuation = _punctuation.replace(char, '')
 
-_token_class = '[A-z0-9%s]' % re.escape(_punctuation_exceptions)
+_punctuation_class = '[%s]' % re.escape(_punctuation)
+_whitespace_class = r'\s+'
+_word_class = '[A-z0-9%s]+' % re.escape(_punctuation_exceptions)
 
-_re_punctuation = re.compile('[%s]' % _punctuation)
-_re_token = re.compile(r'%s+|\s+' % (_token_class))
+_re_punctuation = re.compile(_punctuation_class)
+_re_token = re.compile('%s|%s' % (_whitespace_class, _word_class))
 
 _url_pattern = (
     r'(https?:\/\/)?(([\da-z-]+)\.){1,2}.([a-z\.]{2,6})(/[\/\w \.-]*)*\/?(\?(\w+=\w+&?)+)?'

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -68,11 +68,12 @@ def match_tokens(text, tokenize_whitespace):
 
 
 def get_ngrams(token_list, n=2):
-    ngram = []
     tokens = iter(token_list)
-    for _ in range(0, n):
-        token = next(tokens)
-        ngram.append(token)
+    try:
+        ngram = [next(tokens) for _ in range(0, n)]
+    except StopIteration:
+        return
+
     yield ngram
     for token in tokens:
         ngram = ngram[1:]

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -120,16 +120,16 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
 
     matched_tokens = match_tokens(text, tokenize_whitespace)
     for ngram in get_ngrams(matched_tokens, ngrams):
-        output_tokens = tuple()
+        output_tokens = []
         for token in ngram:
             token = stemmer.stem(token)
             if len(token) < min_length or token in stopwords:
                 break
             if ignore_numeric and isnumeric(token):
                 break
-            output_tokens += (token,)
+            output_tokens.append(token)
         else:
-            yield output_tokens
+            yield tuple(output_tokens)
 
 
 def isnumeric(text):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -102,8 +102,8 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     matched_tokens = match_tokens(text)
     for tokens in get_ngrams(matched_tokens, ngrams):
         candidate = tuple()
-        for i in range(len(tokens)):
-            token = stemmer.stem(tokens[i])
+        for token in tokens:
+            token = stemmer.stem(token)
             if len(token) < min_length or token in stopwords:
                 break
             if ignore_numeric and isnumeric(token):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -58,6 +58,10 @@ def normalize_unicode(text):
         return text
 
 
+def match_tokens(text):
+    return re.findall(_re_token, text)
+
+
 def get_ngrams(token_list, n=2):
     for i in range(len(token_list) - n + 1):
         yield token_list[i:i+n]
@@ -95,7 +99,7 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     text = re.sub(_re_punctuation, '', text)
     text = text if retain_casing else text.lower()
 
-    matched_tokens = re.findall(_re_token, text)
+    matched_tokens = match_tokens(text)
     for tokens in get_ngrams(matched_tokens, ngrams):
         for i in range(len(tokens)):
             tokens[i] = tokens[i].strip(punctuation)

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -101,15 +101,16 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
 
     matched_tokens = match_tokens(text)
     for tokens in get_ngrams(matched_tokens, ngrams):
+        candidate = tuple()
         for i in range(len(tokens)):
-            tokens[i] = stemmer.stem(tokens[i])
-
-            if len(tokens[i]) < min_length or tokens[i] in stopwords:
+            token = stemmer.stem(tokens[i])
+            if len(token) < min_length or token in stopwords:
                 break
-            if ignore_numeric and isnumeric(tokens[i]):
+            if ignore_numeric and isnumeric(token):
                 break
+            candidate += (token,)
         else:
-            yield tuple(tokens)
+            yield candidate
 
 
 def isnumeric(text):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -68,10 +68,10 @@ def get_ngrams(token_list, n=2):
     tokens = iter(token_list)
     try:
         ngram = [next(tokens) for _ in range(0, n)]
+        yield ngram
     except StopIteration:
         return
 
-    yield ngram
     for token in tokens:
         ngram = ngram[1:]
         ngram.append(token)

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -62,9 +62,9 @@ def match_tokens(text):
     return re.findall(_re_token, text)
 
 
-def get_ngrams(token_list, n=2):
-    for i in range(len(token_list) - n + 1):
-        yield token_list[i:i+n]
+def get_ngrams(tokens, n=2):
+    for i in range(len(tokens) - n + 1):
+        yield tokens[i:i+n]
 
 
 def validate_stemmer(stemmer):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -23,8 +23,8 @@ class InvalidStemmerException(Exception):
 _stopwords = frozenset()
 _accepted = frozenset(ascii_letters + digits + punctuation) - frozenset('\'')
 
-# Permit certain characters within punctuation
-_punctuation_exceptions = '\\/-'
+# Permit certain punctuation characters within tokens
+_punctuation_exceptions = r'\/-'
 _punctuation = copy(punctuation)
 for char in _punctuation_exceptions:
     _punctuation = _punctuation.replace(char, '')

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -29,7 +29,7 @@ _punctuation = _punctuation.replace('/', '')
 _punctuation = _punctuation.replace('-', '')
 
 _re_punctuation = re.compile('[%s]' % re.escape(_punctuation))
-_re_token = re.compile(r'[A-z0-9]+')
+_re_token = re.compile(r'[A-z0-9]+|\s+')
 
 _url_pattern = (
     r'(https?:\/\/)?(([\da-z-]+)\.){1,2}.([a-z\.]{2,6})(/[\/\w \.-]*)*\/?(\?(\w+=\w+&?)+)?'
@@ -59,12 +59,9 @@ def normalize_unicode(text):
 
 
 def match_tokens(text, tokenize_whitespace):
-    first = True
     for token in re.findall(_re_token, text):
-        if tokenize_whitespace and not first:
-            yield ' '
-        yield token
-        first = False
+        if token.strip() or tokenize_whitespace:
+            yield token
 
 
 def get_ngrams(token_list, n=2):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -23,13 +23,15 @@ class InvalidStemmerException(Exception):
 _stopwords = frozenset()
 _accepted = frozenset(ascii_letters + digits + punctuation) - frozenset('\'')
 
+# Permit certain characters within punctuation
+_punctuation_exceptions = '\\/-'
 _punctuation = copy(punctuation)
-_punctuation = _punctuation.replace('\\', '')
-_punctuation = _punctuation.replace('/', '')
-_punctuation = _punctuation.replace('-', '')
+_punctuation.strip(_punctuation_exceptions)
 
-_re_punctuation = re.compile('[%s]' % re.escape(_punctuation))
-_re_token = re.compile(r'[A-z0-9]+|\s+')
+_token_class = '[A-z0-9%s]' % re.escape(_punctuation_exceptions)
+
+_re_punctuation = re.compile('[%s]' % _punctuation)
+_re_token = re.compile(r'%s+|\s+' % (_token_class))
 
 _url_pattern = (
     r'(https?:\/\/)?(([\da-z-]+)\.){1,2}.([a-z\.]{2,6})(/[\/\w \.-]*)*\/?(\?(\w+=\w+&?)+)?'

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -78,8 +78,7 @@ def get_ngrams(token_list, n=2):
         return
 
     for token in tokens:
-        ngram = ngram[1:]
-        ngram.append(token)
+        ngram = ngram[1:] + [token]
         yield ngram
 
 

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -67,8 +67,9 @@ def match_tokens(text, tokenize_whitespace):
         first = False
 
 
-def get_ngrams(tokens, n=2):
+def get_ngrams(token_list, n=2):
     ngram = []
+    tokens = iter(token_list)
     for _ in range(0, n):
         token = next(tokens)
         ngram.append(token)

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -58,9 +58,13 @@ def normalize_unicode(text):
         return text
 
 
-def match_tokens(text):
+def match_tokens(text, tokenize_whitespace):
+    first = True
     for token in re.findall(_re_token, text):
+        if tokenize_whitespace and not first:
+            yield ' '
         yield token
+        first = False
 
 
 def get_ngrams(tokens, n=2):
@@ -83,7 +87,7 @@ def validate_stemmer(stemmer):
 
 
 def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_numeric=True,
-                  stemmer=None, retain_casing=False):
+                  stemmer=None, retain_casing=False, tokenize_whitespace=False):
     """
     Parses the given text and yields tokens which represent words within
     the given text. Tokens are assumed to be divided by any form of
@@ -107,7 +111,7 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
     text = re.sub(_re_punctuation, '', text)
     text = text if retain_casing else text.lower()
 
-    matched_tokens = match_tokens(text)
+    matched_tokens = match_tokens(text, tokenize_whitespace)
     for tokens in get_ngrams(matched_tokens, ngrams):
         candidate = tuple()
         for token in tokens:

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -99,6 +99,9 @@ def word_tokenize(text, stopwords=_stopwords, ngrams=None, min_length=0, ignore_
 
     Generated tokens are lowercased by default; the retain_casing flag can
     be set to True to retain upper/lower casing from the original text.
+
+    Whitespace tokens are omitted by default; the tokenize_whitespace flag can
+    be set to True to include whitespace tokens in the output stream.
     """
     if ngrams is None:
         ngrams = 1

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -70,14 +70,14 @@ class IsNumericTestCase(unittest.TestCase):
 
 class GetNGramsTestCase(unittest.TestCase):
 
-    def test_bigram_tokens(self):
+    def test_bigram_token_list(self):
         assert list(textparser.get_ngrams(
-            tokens=iter(['one', 'two', 'three', 'four']),
+            token_list=['one', 'two', 'three', 'four'],
         )) == [['one', 'two'], ['two', 'three'], ['three', 'four']]
 
-    def test_trigram_tokens(self):
+    def test_trigram_token_list(self):
         assert list(textparser.get_ngrams(
-            tokens=iter(['one', 'two', 'three', 'four']),
+            token_list=['one', 'two', 'three', 'four'],
             n=3,
         )) == [
             ['one', 'two', 'three'],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -72,12 +72,12 @@ class GetNGramsTestCase(unittest.TestCase):
 
     def test_bigram_tokens(self):
         assert list(textparser.get_ngrams(
-            tokens=['one', 'two', 'three', 'four'],
+            tokens=iter(['one', 'two', 'three', 'four']),
         )) == [['one', 'two'], ['two', 'three'], ['three', 'four']]
 
     def test_trigram_tokens(self):
         assert list(textparser.get_ngrams(
-            tokens=['one', 'two', 'three', 'four'],
+            tokens=iter(['one', 'two', 'three', 'four']),
             n=3,
         )) == [
             ['one', 'two', 'three'],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -172,6 +172,19 @@ class WordTokenizeTestCase(unittest.TestCase):
             tokenize_whitespace=True
         )) == [('around',), ('   ',), ('the',), (' ',), ('world', )]
 
+    def test_tokenize_punctuation_and_whitespace(self):
+        assert list(textparser.word_tokenize(
+            text='who, where, what, when, why?',
+            retain_punctuation=True,
+            tokenize_whitespace=True
+        )) == [
+            ('who',), (',',), (' ',),
+            ('where',), (',',), (' ',),
+            ('what',), (',',), (' ',),
+            ('when',), (',',), (' ',),
+            ('why',), ('?',),
+        ]
+
 
 class TestNullStemmer(unittest.TestCase):
     def test_repr(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -131,12 +131,6 @@ class WordTokenizeTestCase(unittest.TestCase):
             retain_casing=True
         )) == [('Three', ), ('letter', ), ('acronym', ), ('TLA',)]
 
-    def test_tokenize_whitespace(self):
-        assert list(textparser.word_tokenize(
-            text='around   the world',
-            tokenize_whitespace=True
-        )) == [('around',), ('   ',), ('the',), (' ',), ('world', )]
-
     def test_ngrams(self):
         assert list(textparser.word_tokenize(
             text='foo bar bomb blar',
@@ -154,6 +148,12 @@ class WordTokenizeTestCase(unittest.TestCase):
             text='one examples',
             stemmer=self.NaivePluralStemmer()
         )) == [('one',), ('example',)]
+
+    def test_tokenize_whitespace(self):
+        assert list(textparser.word_tokenize(
+            text='around   the world',
+            tokenize_whitespace=True
+        )) == [('around',), ('   ',), ('the',), (' ',), ('world', )]
 
 
 class TestNullStemmer(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -143,6 +143,12 @@ class WordTokenizeTestCase(unittest.TestCase):
             ngrams=2,
         )) == [('foo', 'bar'), ('bar', 'bomb'), ('bomb', 'blar')]
 
+    def test_ngram_unsatisfiable(self):
+        assert list(textparser.word_tokenize(
+            text='foo bar',
+            ngrams=3,
+        )) == []
+
     def test_stemming(self):
         assert list(textparser.word_tokenize(
             text='one examples',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -70,14 +70,14 @@ class IsNumericTestCase(unittest.TestCase):
 
 class GetNGramsTestCase(unittest.TestCase):
 
-    def test_bigram_token_list(self):
+    def test_bigram_tokens(self):
         assert list(textparser.get_ngrams(
-            token_list=['one', 'two', 'three', 'four'],
+            tokens=['one', 'two', 'three', 'four'],
         )) == [['one', 'two'], ['two', 'three'], ['three', 'four']]
 
-    def test_trigram_token_list(self):
+    def test_trigram_tokens(self):
         assert list(textparser.get_ngrams(
-            token_list=['one', 'two', 'three', 'four'],
+            tokens=['one', 'two', 'three', 'four'],
             n=3,
         )) == [
             ['one', 'two', 'three'],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -135,7 +135,7 @@ class WordTokenizeTestCase(unittest.TestCase):
         assert list(textparser.word_tokenize(
             text='around   the world',
             tokenize_whitespace=True
-        )) == [('around',), (' ',), ('the',), (' ',), ('world', )]
+        )) == [('around',), ('   ',), ('the',), (' ',), ('world', )]
 
     def test_ngrams(self):
         assert list(textparser.word_tokenize(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -131,6 +131,11 @@ class WordTokenizeTestCase(unittest.TestCase):
             retain_casing=True
         )) == [('Three', ), ('letter', ), ('acronym', ), ('TLA',)]
 
+    def test_tokenize_whitespace(self):
+        assert list(textparser.word_tokenize(
+            text='around   the world',
+        )) == [('around',), (' ',), ('the',), (' ',), ('world', )]
+
     def test_ngrams(self):
         assert list(textparser.word_tokenize(
             text='foo bar bomb blar',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -134,6 +134,7 @@ class WordTokenizeTestCase(unittest.TestCase):
     def test_tokenize_whitespace(self):
         assert list(textparser.word_tokenize(
             text='around   the world',
+            tokenize_whitespace=True
         )) == [('around',), (' ',), ('the',), (' ',), ('world', )]
 
     def test_ngrams(self):


### PR DESCRIPTION
As [discussed](https://github.com/MichaelAquilina/hashedindex/pull/16#issuecomment-621890496) in #16, it can be useful to enable the output of tokens for whitespace elements during string tokenization.

This changeset implements support for optional whitespace token generation.