### PR TITLE
Cleanup: update Python version support references

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,9 +99,9 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.3, and 3.4, and for PyPy. Check
-   https://travis-ci.org/MichaelAquilina/hashedindex/pull_requests
-   and make sure that the tests pass for all supported Python versions.
+3. The pull request should work for supported Python versions, as listed in `.travis.yml` and `setup.py`.
+   Check https://travis-ci.org/MichaelAquilina/hashedindex/pull_requests
+   and make sure that the tests pass for all platforms.
 
 Tips
 ----

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',


### PR DESCRIPTION
This tidies up some references to Python 3.4, which is no longer supported by `hashedindex` ([ref](https://github.com/MichaelAquilina/hashedindex/blob/714293e2c70770ca8c18f10dfb129b65e0089fd1/HISTORY.rst#050-2019-07-21)) or the Python project ([ref](https://docs.python.org/3.4/)).