### PR TITLE
Tokenization: support non-ascii characters during tokenization

### DIFF
--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -31,7 +31,7 @@ for char in _punctuation_exceptions:
 
 _punctuation_class = '[%s]' % re.escape(_punctuation)
 _whitespace_class = r'\s+'
-_word_class = '[A-z0-9%s]+' % re.escape(_punctuation_exceptions)
+_word_class = r'[\w%s]+' % re.escape(_punctuation_exceptions)
 
 _re_punctuation = re.compile(_punctuation_class)
 _re_token = re.compile('%s|%s|%s' % (_punctuation_class, _whitespace_class, _word_class))

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -1,6 +1,5 @@
 import re
 import math
-import unicodedata
 
 from copy import copy
 from string import punctuation
@@ -49,17 +48,6 @@ def tfidf(tf, df, corpus_size):
         return (1 + math.log(tf)) * math.log(corpus_size / df)
     else:
         return 0.0
-
-
-def normalize_unicode(text):
-    """
-    Normalize any unicode characters to ascii equivalent
-    https://docs.python.org/2/library/unicodedata.html#unicodedata.normalize
-    """
-    if isinstance(text, str):
-        return unicodedata.normalize('NFKD', text).encode('ascii', 'ignore').decode('utf8')
-    else:
-        return text
 
 
 def match_tokens(text, tokenize_whitespace):

--- a/hashedindex/textparser.py
+++ b/hashedindex/textparser.py
@@ -3,7 +3,7 @@ import math
 import unicodedata
 
 from copy import copy
-from string import ascii_letters, digits, punctuation
+from string import punctuation
 
 
 # Stemmer interface which returns token unchanged
@@ -21,7 +21,6 @@ class InvalidStemmerException(Exception):
 
 
 _stopwords = frozenset()
-_accepted = frozenset(ascii_letters + digits + punctuation) - frozenset('\'')
 
 # Permit certain punctuation characters within tokens
 _punctuation_exceptions = r'\/-'

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -148,6 +148,9 @@ class WordTokenizeTestCase(unittest.TestCase):
             retain_punctuation=True
         )) == [('is', ), ('the', ), ('oven',), ('pre-heated', ), ('?',)]
 
+    def test_retain_unicode_within_tokens(self):
+        assert list(textparser.word_tokenize('québec')) == [('québec',)]
+
     def test_ngrams(self):
         assert list(textparser.word_tokenize(
             text='foo bar bomb blar',

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -199,14 +199,6 @@ class TestNullStemmer(unittest.TestCase):
         assert stemmer.stem('hello  ') == 'hello  '
 
 
-class NormalizeUnicode(unittest.TestCase):
-    def test_empty(self):
-        assert textparser.normalize_unicode('') == ''
-
-    def test_correct_output(self):
-        assert textparser.normalize_unicode('iäöü') == 'iaou'
-
-
 class IsUrlTestCase(unittest.TestCase):
 
     def test_http_url(self):


### PR DESCRIPTION
The [`textparser._word_class`](https://github.com/MichaelAquilina/hashedindex/blob/714293e2c70770ca8c18f10dfb129b65e0089fd1/hashedindex/textparser.py#L34) regular expression determines the characters that are considered part of each word during tokenization.

This change modifies the regular expression so that it no longer relies on a fixed `A-z0-9` definition of alphanumeric characters, but instead uses the [`\w` special character](https://docs.python.org/3.5/library/re.html) to support character sets according to the environment's `LOCALE` and `UNICODE` settings.