### PR TITLE
Allow callers of 'add_term_occurrence' to specify a custom occurrence count

### DIFF
--- a/hashedindex/__init__.py
+++ b/hashedindex/__init__.py
@@ -63,9 +63,9 @@ class HashedIndex:
         """
         self._freeze = False
 
-    def add_term_occurrence(self, term, document):
+    def add_term_occurrence(self, term, document, count=1):
         """
-        Adds an occurrence of the term in the specified document.
+        Adds occurrence(s) (default: 1) of the term in the specified document.
         """
         if document not in self._documents:
             self._documents[document] = 0
@@ -79,8 +79,8 @@ class HashedIndex:
         if document not in self._terms[term]:
             self._terms[term][document] = 0
 
-        self._documents[document] += 1
-        self._terms[term][document] += 1
+        self._documents[document] += count
+        self._terms[term][document] += count
 
     def get_total_term_frequency(self, term):
         """

--- a/tests/test_hashedindex.py
+++ b/tests/test_hashedindex.py
@@ -19,18 +19,10 @@ class HashedIndexTest(unittest.TestCase):
 
     def setUp(self):
         self.index = hashedindex.HashedIndex()
-
-        for i in range(3):
-            self.index.add_term_occurrence('word', 'document1.txt')
-
-        for i in range(5):
-            self.index.add_term_occurrence('malta', 'document1.txt')
-
-        for i in range(4):
-            self.index.add_term_occurrence('phone', 'document2.txt')
-
-        for i in range(2):
-            self.index.add_term_occurrence('word', 'document2.txt')
+        self.index.add_term_occurrence('word', 'document1.txt', count=3)
+        self.index.add_term_occurrence('malta', 'document1.txt', count=5)
+        self.index.add_term_occurrence('phone', 'document2.txt', count=4)
+        self.index.add_term_occurrence('word', 'document2.txt', count=2)
 
     def test_repr(self):
         index = hashedindex.HashedIndex()
@@ -352,18 +344,10 @@ class HashedIndexTest(unittest.TestCase):
 class SerializationTest(unittest.TestCase):
     def setUp(self):
         self.index = hashedindex.HashedIndex()
-
-        for i in range(3):
-            self.index.add_term_occurrence('word', 'document1.txt')
-
-        for i in range(5):
-            self.index.add_term_occurrence('malta', 'document1.txt')
-
-        for i in range(4):
-            self.index.add_term_occurrence('phone', 'document2.txt')
-
-        for i in range(2):
-            self.index.add_term_occurrence('word', 'document2.txt')
+        self.index.add_term_occurrence('word', 'document1.txt', count=3)
+        self.index.add_term_occurrence('malta', 'document1.txt', count=5)
+        self.index.add_term_occurrence('phone', 'document2.txt', count=4)
+        self.index.add_term_occurrence('word', 'document2.txt', count=2)
 
     def test_to_dict(self):
         assert self.index.to_dict() == {


### PR DESCRIPTION
This change allows callers of `add_term_occurrence` to specify a custom `count` value, which defaults to `1` (existing behaviour).  The term frequency count for the document -- and the document frequency count within the term -- are both incremented by this value.

The typical use case for this is that a caller has already calculated term frequencies for a document, and so it is redundant to perform loops for each term in order to increment them the correct number of times in the index.